### PR TITLE
Remove Branch Name From requirements.yml

### DIFF
--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -3,9 +3,7 @@
 - name: 'openstack-repo'
   src: 'abelboldu.openstack-repo'
 
-- name: 'openstack-keystone'
-  src: 'https://github.com/openstack-ansible-galaxy/openstack-keystone'
-  version: 'origin/features/mitaka'
-
 - name: 'mysql'
   src: 'geerlingguy.mysql'
+
+- src: 'https://github.com/openstack-ansible-galaxy/openstack-keystone'


### PR DESCRIPTION
Since `openstack-keystone` role changed its branch name from
`features/mitaka` to `master`, Ansible Galaxy `requirements.yml` for
this role needs to change it as well.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
