### PR TITLE
Change yamllint Line Length

### DIFF
--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -4,4 +4,4 @@ extends: default
 
 rules:
   line-length:
-    max: 120
+    max: 160


### PR DESCRIPTION
Due to the modification of Ansible Role Style Guide, yamllint check
needs to be modified.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
